### PR TITLE
Added rolling endpoint support

### DIFF
--- a/pybamboo/dataset.py
+++ b/pybamboo/dataset.py
@@ -403,6 +403,40 @@ class Dataset(object):
                 'GET', '/datasets/%s/resample' % self._id, params=params)
         return _resample(self, date_column, interval, how, query, format)
 
+    def rolling(self, win_type=None, window=None, format=None,
+                num_retries=NUM_RETRIES):
+        """
+            To compute moving or rolling statistics / moments
+
+            you can use the rolling request.
+            Any options that can be passed to the pandas
+            rolling_window function can be passed as parameters to bamboo.
+            http://pandas.pydata.org/pandas-docs/dev
+                /computation.html#moving-rolling-statistics-moments
+            Window types are passed as the win_type parameter.
+        """
+
+        @require_valid
+        def _rolling(self, win_type, window, format):
+            params = {}
+            if win_type:
+                if not isinstance(win_type, basestring):
+                    raise PyBambooException('win_type must be a string.')
+                params['win_type'] = win_type
+
+            if not window or not isinstance(window, int):
+                raise PyBambooException('window must be an int')
+            params['window'] = window
+
+            if format:
+                if not isinstance(format, basestring):
+                    raise PyBambooException('format must be a string.')
+                params['format'] = format
+
+            return self._connection.make_api_request(
+                'GET', '/datasets/%s/rolling' % self._id, params=params)
+        return _rolling(self, win_type, window, format)
+
     @require_valid
     def update_data(self, rows):
         """

--- a/pybamboo/tests/test_dataset.py
+++ b/pybamboo/tests/test_dataset.py
@@ -82,6 +82,10 @@ class TestDataset(TestBase):
                                      how='sum')
         self.assertTrue(data)
 
+    def test_rolling(self):
+        data = self.dataset.rolling(win_type='boxcar', window=3)
+        self.assertTrue(isinstance(data, list))
+
     def test_str(self):
         self.assertEqual(str(self.dataset), self.dataset.id)
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from distutils.core import setup
 
 setup(
-     name='pybamboo',
-     version='0.5.7.7',
-     author='modilabs',
-     author_email='info@modilabs.org',
-     packages=['pybamboo'],
-     package_dir={'pybamboo': 'pybamboo'},
-     url='http://pypi.python.org/pypi/pybamboo/',
-     description='A Python package to interact with bamboo.io.',
-     long_description=open('README.rst', 'rt').read(),
-     install_requires=[
+    name='pybamboo',
+    version='0.5.7.7',
+    author='modilabs',
+    author_email='info@modilabs.org',
+    packages=['pybamboo'],
+    package_dir={'pybamboo': 'pybamboo'},
+    url='http://pypi.python.org/pypi/pybamboo/',
+    description='A Python package to interact with bamboo.io.',
+    long_description=open('README.rst', 'rt').read(),
+    install_requires=[
         'requests==0.14.0',
         'simplejson==2.6.2',
         'pymongo==2.3'


### PR DESCRIPTION
Following update of pybamboo: #12 

Support for http://bamboo.io/docs/advanced_commands.html#calculating-rolling-statistics
