### PR TITLE
users can set/update the label, description, license, and attribution per dataset

### DIFF
--- a/pybamboo/dataset.py
+++ b/pybamboo/dataset.py
@@ -301,19 +301,19 @@ class Dataset(object):
         @retry(num_retries)
         def _set_info(self, attribution, description, label, license):
             params = {}
-            if attribution:
+            if attribution is not None:
                 if not isinstance(attribution, basestring):
                     raise PyBambooException('attribution must be a string.')
                 params['attribution'] = attribution
-            if description:
+            if description is not None:
                 if not isinstance(description, basestring):
                     raise PyBambooException('description must be a string.')
                 params['description'] = description
-            if label:
+            if label is not None:
                 if not isinstance(label, basestring):
                     raise PyBambooException('label must be a string.')
                 params['label'] = label
-            if license:
+            if license is not None:
                 if not isinstance(license, basestring):
                     raise PyBambooException('license must be a string.')
                 params['license'] = license

--- a/pybamboo/dataset.py
+++ b/pybamboo/dataset.py
@@ -291,6 +291,36 @@ class Dataset(object):
                 'GET', '/datasets/%s/info' % self._id, params=params)
         return _get_info(self, callback)
 
+    def set_info(self, attribution=None, description=None,
+                 label=None, license=None,
+                 num_retries=NUM_RETRIES):
+        """
+        Set metadata on the dataset
+        """
+        @require_valid
+        @retry(num_retries)
+        def _set_info(self, attribution, description, label, license):
+            params = {}
+            if attribution:
+                if not isinstance(attribution, basestring):
+                    raise PyBambooException('attribution must be a string.')
+                params['attribution'] = attribution
+            if description:
+                if not isinstance(description, basestring):
+                    raise PyBambooException('description must be a string.')
+                params['description'] = description
+            if label:
+                if not isinstance(label, basestring):
+                    raise PyBambooException('label must be a string.')
+                params['label'] = label
+            if license:
+                if not isinstance(license, basestring):
+                    raise PyBambooException('license must be a string.')
+                params['license'] = license
+            return self._connection.make_api_request(
+                'PUT', '/datasets/%s/info' % self._id, data=params)
+        return _set_info(self, attribution, description, label, license)
+
     def get_data(self, select=None, query=None, order_by=None, limit=0,
                  distinct=None, format=None, callback=None, count=False,
                  num_retries=NUM_RETRIES):

--- a/pybamboo/tests/test_dataset.py
+++ b/pybamboo/tests/test_dataset.py
@@ -86,6 +86,21 @@ class TestDataset(TestBase):
         data = self.dataset.rolling(win_type='boxcar', window=3)
         self.assertTrue(isinstance(data, list))
 
+    def test_set_info(self):
+        description = u"Meals rating worldwide"
+        attribution = u"mberg"
+        label = u"Good Eats"
+        license = u"Public Domain"
+        self.dataset.set_info(attribution=attribution,
+                      description=description,
+                      label=label,
+                      license=license)
+        infos = self.dataset.get_info()
+        self.assertEqual(infos['description'], description)
+        self.assertEqual(infos['attribution'], attribution)
+        self.assertEqual(infos['label'], label)
+        self.assertEqual(infos['license'], license)
+
     def test_str(self):
         self.assertEqual(str(self.dataset), self.dataset.id)
 

--- a/pybamboo/tests/test_dataset.py
+++ b/pybamboo/tests/test_dataset.py
@@ -92,9 +92,9 @@ class TestDataset(TestBase):
         label = u"Good Eats"
         license = u"Public Domain"
         self.dataset.set_info(attribution=attribution,
-                      description=description,
-                      label=label,
-                      license=license)
+                              description=description,
+                              label=label,
+                              license=license)
         infos = self.dataset.get_info()
         self.assertEqual(infos['description'], description)
         self.assertEqual(infos['attribution'], attribution)


### PR DESCRIPTION
users can set/update the label, description, license, and attribution per dataset, http://bamboo.io/docs/advanced_commands.html#updating-dataset-metadata
- new endpoint PUT datasets/[ID]/info

Implemented as `dataset.set_info(attribution=None, description=None, license=None, label=None)`

Only non-None parameters are updated. Empty strings allowed.
