### PR TITLE
Bamboo server can be set for tests

### DIFF
--- a/pybamboo/tests/test_base.py
+++ b/pybamboo/tests/test_base.py
@@ -16,7 +16,12 @@ class TestBase(unittest.TestCase):
     AUX_CSV_FILE = os.getcwd() + '/tests/fixtures/good_eats_aux.csv'
     NUM_COLS = 15
     NUM_ROWS = 19
-    TEST_BAMBOO_URL = DEFAULT_BAMBOO_URL
+    # use this to forward tests to a different bamboo instance
+    TEST_BAMBOO_URL = os.environ.get('TEST_BAMBOO_URL', DEFAULT_BAMBOO_URL)
+    # change this only to test while offline
+    DEFAULT_BAMBOO_URL = os.environ.get('DEFAULT_BAMBOO_URL',
+                                        DEFAULT_BAMBOO_URL)
+
     VERSION_KEYS = [
         'version',
         'description',
@@ -29,6 +34,7 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.bamboo_url = self.TEST_BAMBOO_URL
         self.connection = Connection(self.bamboo_url)
+        self.default_connection = Connection(DEFAULT_BAMBOO_URL)
 
         # these two datasets (if created) will automatically
         # get deleted by the test harness

--- a/pybamboo/tests/test_dataset.py
+++ b/pybamboo/tests/test_dataset.py
@@ -10,7 +10,8 @@ class TestDataset(TestBase):
         self._create_dataset_from_file()
 
     def _create_dataset_from_file(self):
-        self.dataset = Dataset(path=self.CSV_FILE, connection=self.connection)
+        self.dataset = Dataset(path=self.CSV_FILE,
+                               connection=self.connection)
         self.wait()
 
     def _create_aux_dataset_from_file(self):
@@ -19,45 +20,52 @@ class TestDataset(TestBase):
         self.wait()
 
     def test_create_dataset_from_json(self):
-        dataset = Dataset(path=self.JSON_FILE, data_format='json')
+        dataset = Dataset(path=self.JSON_FILE, data_format='json',
+                          connection=self.connection)
         self.assertTrue(dataset.id is not None)
         self._cleanup(dataset)
 
     def test_create_dataset_from_schema(self):
-        dataset = Dataset(schema_path=self.SCHEMA_FILE)
+        dataset = Dataset(schema_path=self.SCHEMA_FILE,
+                          connection=self.connection)
         self.assertTrue(dataset.id is not None)
         self._cleanup(dataset)
 
         # schema string
         schema_str = open(self.SCHEMA_FILE).read()
-        dataset = Dataset(schema_content=schema_str)
+        dataset = Dataset(schema_content=schema_str,
+                          connection=self.connection)
         self.assertTrue(dataset.id is not None)
         self._cleanup(dataset)
 
     def test_create_dataset_from_schema_with_data(self):
         # schema + JSON data
         dataset = Dataset(path=self.JSON_FILE, data_format='json',
-                          schema_path=self.SCHEMA_FILE)
+                          schema_path=self.SCHEMA_FILE,
+                          connection=self.connection)
         self.assertTrue(dataset.id is not None)
         self._cleanup(dataset)
 
         # schema + CSV data
         dataset = Dataset(path=self.CSV_FILE, data_format='csv',
-                          schema_path=self.SCHEMA_FILE)
+                          schema_path=self.SCHEMA_FILE,
+                          connection=self.connection)
         self.assertTrue(dataset.id is not None)
         self._cleanup(dataset)
 
     def test_create_dataset_default_connection(self):
-        dataset = Dataset(path=self.CSV_FILE)
+        dataset = Dataset(path=self.CSV_FILE,
+                          connection=self.default_connection)
         self._cleanup(dataset)
 
     def test_create_dataset_no_info(self):
         with self.assertRaises(PyBambooException):
-            dataset = Dataset()
+            Dataset()
 
     def test_create_dataset_bad_data_format(self):
         with self.assertRaises(PyBambooException):
-            dataset = Dataset(path=self.CSV_FILE, data_format='BAD')
+            Dataset(path=self.CSV_FILE, data_format='BAD',
+                              connection=self.connection)
 
     def test_create_dataset_from_file(self):
         # created in TestDataset.setUp()
@@ -65,7 +73,8 @@ class TestDataset(TestBase):
 
     def test_create_dataset_from_url(self):
         dataset = Dataset(
-            url='http://formhub.org/mberg/forms/good_eats/data.csv')
+            url='http://formhub.org/mberg/forms/good_eats/data.csv',
+            connection=self.connection)
         self.assertTrue(self.dataset.id is not None)
         self._cleanup(dataset)
 
@@ -410,8 +419,10 @@ class TestDataset(TestBase):
         self._cleanup(result)
 
     def test_merge_default_connection(self):
-        dataset = Dataset(path=self.CSV_FILE)
-        other_dataset = Dataset(path=self.CSV_FILE)
+        dataset = Dataset(path=self.CSV_FILE,
+                          connection=self.default_connection)
+        other_dataset = Dataset(path=self.CSV_FILE,
+                                connection=self.default_connection)
         result = Dataset.merge([dataset, other_dataset])
         self.assertTrue(isinstance(result, Dataset))
         self._cleanup(dataset)
@@ -441,8 +452,10 @@ class TestDataset(TestBase):
         self._cleanup(result)
 
     def test_join_default_connection(self):
-        dataset = Dataset(path=self.CSV_FILE)
-        aux_dataset = Dataset(path=self.AUX_CSV_FILE)
+        dataset = Dataset(path=self.CSV_FILE,
+                          connection=self.default_connection)
+        aux_dataset = Dataset(path=self.AUX_CSV_FILE,
+                              connection=self.default_connection)
         self.wait()
         result = Dataset.join(dataset, aux_dataset, 'food_type')
         self.assertTrue(isinstance(result, Dataset))


### PR DESCRIPTION
Use `TEST_BAMBOO_URL="http://localhost:8080" nosetests` to forward the tests to a local installation.

Some tests are still taregtting the bamboo.io server intentionally. It is possible to change it (while offline) using:
`DEFAULT_BAMBOO_URL="http://localhost:8080" TEST_BAMBOO_URL="http://localhost:8080" nosetests`
