### PR TITLE
Revamped calculations/aggregations methods

### DIFF
--- a/pybamboo/dataset.py
+++ b/pybamboo/dataset.py
@@ -111,14 +111,22 @@ class Dataset(object):
                         num_retries=NUM_RETRIES):
         """
         Adds a calculation to this dataset in bamboo.
+
+        A calculation is defined by:
+        :param str name: the formula name by which you'll identify it.
+        :param str formula: the actual formula using bamboo syntax.
+            cf. http://bamboo.io/docs/index.html#formula-reference
+        :param list groups: optionnal, a list of fields to group on.
+
+        .. note ::
+            http://bamboo.io/docs/basic_commands.html#calculation-formulas
         """
         @require_valid
         @retry(num_retries)
         def _add_calculation(self, formula, name, groups):
-            if formula is None or name is None \
-                or not isinstance(formula, basestring) \
-                or not isinstance(name, basestring):
-
+            if (formula is None or name is None
+                or not isinstance(formula, basestring)
+                or not isinstance(name, basestring)):
                 raise PyBambooException('name & formula must be strings.')
 
             data = {'name': name, 'formula': formula}
@@ -139,7 +147,22 @@ class Dataset(object):
                          json=None,
                          num_retries=NUM_RETRIES):
         """
-        Adds a list of calculations to this dataset in bamboo.
+        Adds a JSON-formatted list of calculations to this dataset in bamboo.
+
+        Calculations are defined by a name, a formula and an optionnal grouping
+        This method takes a JSON list of dict, each containing:
+        * str name
+        * str formula
+        * list group (optionnal)
+
+        JSON content can be send in 3 ways:
+        :param str path: localation of a valid JSON file.
+        :param StringIO content: a file-like object containing valid JSON
+        :param dict json: a Python list of dict to be serialized.
+
+        .. note ::
+            http://bamboo.io/docs/advanced_commands.html
+                                  #creating-multiple-calculations-via-json
         """
         @require_valid
         @retry(num_retries)


### PR DESCRIPTION
Simplified the way we deal with calculations and aggregation.
I believe we got a little too excited when we started pybamboo and wanted
to add too much value to it.

I think that until we have users' requests and documentation, we should keep close
to the actual Bamboo API.

I thus removed the notion of aggregation since bamboo doesn't use such language.

To work with them, now we have:
- `add_calculation(name='sum_of_amount', formula='sum(amount)', groups=['food_type,something_else', 'another'])`
- `add_calculations(path='/tmp/my_calcs.json')`
- `add_calculations(json=[{"name": "sum_of_amount", "formula": "sum(amount)", "groups": ["risk_factor", "food_type"]}])`
- `add_calculations(content='[{"formula": "sum(amount)", "name": "sum_of_amount", "groups": ["risk_factor", "food_type"]}]')`
- `remove_calculation(name)`
- `get_calculations()`
- `get_aggregate_datasets` # added a get_aggregations() alias for it to match bamboo API name

Simpler right ?

So I removed the following:
- `add_calculation(formula)` # managing the formula string by hand seems anti-pythonic.
- `_split_formula(formula)` # dependency of above.
- `_is_formula_an_aggregation(formula)` # idem.
- `_process_formula(formula, is_aggregation=False, as_dict=False)` # idem.
- `add_calculations(formulae)` # used to batch calculation creation as a list of previouly formatted strings. Now we'd just send a list of dicts.
- `add_aggregation(formula, groups=None)` # was a `shortcut` to calculation with a group. Useless.

Tests have all been adapted and passes.
